### PR TITLE
Added Shadow DOM support to the graphs and tooltips.

### DIFF
--- a/src/core/connected-graph/base.ts
+++ b/src/core/connected-graph/base.ts
@@ -112,7 +112,8 @@ export class ConnectedGraphBase {
 
     bind(renderer: UIRenderer, graph: IPortDiagram,
         getSelectionString: (data: any) => string,
-        getTooltipString: (data: any) => string) {
+        getTooltipString: (data: any) => string,
+        documentRoot: DocumentFragment) {
 
         let self = this;
         this.getSelectionString = getSelectionString ? getSelectionString :
@@ -210,7 +211,7 @@ export class ConnectedGraphBase {
             return true;
         }
 
-        this._dataTooltip = new CustomDivTooltip(this._tooltipId, 'tooltip-t');
+        this._dataTooltip = new CustomDivTooltip(this._tooltipId, 'tooltip-t', documentRoot);
         this._dataTooltip
             .setAnalyticsName(this._tooltipAnalyticsName)
             .setEnterCallback(showTooltip)
@@ -534,7 +535,7 @@ export class ConnectedGraphBase {
             // the selection brush
             self._svg.select('.brush').remove();
 
-            self._brushTooltip = new OneLineTooltip('brush', 'tooltip-t');
+            self._brushTooltip = new OneLineTooltip('brush', 'tooltip-t', documentRoot);
             self._brushTooltip
                 .setPlaceTooltipLeftRight()
                 .alwaysRecalcWidth(true)
@@ -632,13 +633,15 @@ export class D3ConnectedGraphSVG extends SVGRenderer {
         height: number, width: number) => void;
 
     constructor(element: UIElement, renderer: UIRenderer,
-        parent: d3.Selection<any, any, d3.BaseType, any>) {
+        parent: d3.Selection<any, any, d3.BaseType, any>,
+        documentRoot: DocumentFragment = document
+    ) {
         super();
 
         this.initialize(element, renderer, parent);
         this._graphContainer = this._svg;
 
-        ConnectedGraphBase.prototype.bind.call(this, renderer, element);
+        ConnectedGraphBase.prototype.bind.call(this, renderer, element, null, null, documentRoot);
     }
 
     protected renderLegend(graphHeight?: number): number {

--- a/src/core/connected-graph/force.ts
+++ b/src/core/connected-graph/force.ts
@@ -14,9 +14,10 @@ import { ConnectedGraphBase } from './base';
 
 export class D3ForceGraph extends D3SimpleGraph {
     constructor(element: UIElement, renderer: D3Renderer,
-        parent: d3.Selection<any, any, d3.BaseType, any>) {
+        parent: d3.Selection<any, any, d3.BaseType, any>,
+        documentRoot: DocumentFragment = document) {
 
-        super(element, renderer, parent);
+        super(element, renderer, parent, documentRoot);
 
         ConnectedGraphBase.prototype.initializeGraph.call(this, element as IConnectedGraph);
     }

--- a/src/core/connected-graph/hierarchy.ts
+++ b/src/core/connected-graph/hierarchy.ts
@@ -47,9 +47,10 @@ export class D3HierarchyGraph extends D3ConnectedGraphSVG {
     protected _nodes: any;
 
     constructor(element: UIElement, renderer: D3Renderer,
-        parent: d3.Selection<any, any, d3.BaseType, any>) {
+        parent: d3.Selection<any, any, d3.BaseType, any>,
+        documentRoot: DocumentFragment) {
 
-        super(element, renderer, parent);
+        super(element, renderer, parent, documentRoot);
 
         // undo auto width from initialize call
         this._options.width = undefined;

--- a/src/core/connected-graph/port.ts
+++ b/src/core/connected-graph/port.ts
@@ -773,8 +773,10 @@ export class D3PortDiagramSVG extends D3ConnectedGraphSVG {
 
     constructor(element: UIElement, renderer: UIRenderer,
         parent: d3.Selection<any, any, d3.BaseType, any>,
-        portDiagram: D3PortDiagram) {
-        super(element, renderer, parent);
+        portDiagram: D3PortDiagram,
+        documentRoot: DocumentFragment = document
+    ) {
+        super(element, renderer, parent, documentRoot);
 
         DiagramBase.prototype.bind.call(this, this._renderer, this._element);
 

--- a/src/core/connected-graph/sankey.ts
+++ b/src/core/connected-graph/sankey.ts
@@ -13,9 +13,11 @@ export class D3SankeyDiagram extends D3ConnectedGraphSVG {
     private _sankey: any;
 
     constructor(element: UIElement, renderer: D3Renderer,
-        parent: d3.Selection<any, any, d3.BaseType, any>) {
+        parent: d3.Selection<any, any, d3.BaseType, any>,
+        documentRoot: DocumentFragment = document
+    ) {
 
-        super(element, renderer, parent);
+        super(element, renderer, parent, documentRoot);
 
         ConnectedGraphBase.prototype.initializeGraph.call(this, element);
     }

--- a/src/core/connected-graph/simple.ts
+++ b/src/core/connected-graph/simple.ts
@@ -9,9 +9,11 @@ import { ConnectedGraphBase, D3ConnectedGraphSVG } from './base';
 
 export class D3SimpleGraph extends D3ConnectedGraphSVG {
     constructor(element: UIElement, renderer: D3Renderer,
-        parent: d3.Selection<any, any, d3.BaseType, any>) {
+        parent: d3.Selection<any, any, d3.BaseType, any>,
+        documentRoot: DocumentFragment = document
+    ) {
 
-        super(element, renderer, parent);
+        super(element, renderer, parent, documentRoot);
 
         ConnectedGraphBase.prototype.initializeGraph.call(this, element as IConnectedGraph);
 

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -46,8 +46,6 @@ export class D3Renderer implements UIRenderer {
 
     /** The parent id of the div */
     protected _parent: d3.Selection<d3.BaseType, any, d3.BaseType, any>;
-    protected _parentId: string;
-    protected _colorMgr: ColorManager;
 
     /** maps to render elements if multiple renders are used
      *  through this interface */
@@ -56,13 +54,13 @@ export class D3Renderer implements UIRenderer {
     // from UIRenderer
     public onRender: (elem: UIElement, options: IOptions) => void;
 
-    constructor(parentId?: string, colorMgr: ColorManager = new ColorManager()) {
-        if (parentId) {
-            this._parentId = parentId;
-            this._parent = d3.select('body').select(parentId);
-        }
-        if (colorMgr) {
-            this._colorMgr = colorMgr;
+    constructor(
+        protected _parentId?: string, 
+        protected _colorMgr: ColorManager = new ColorManager(), 
+        protected _documentRoot: DocumentFragment = document
+    ) {
+        if (this._parentId) {
+            this._parent = d3.select(this._documentRoot).select(this._parentId);
         }
 
         this._rendererMap = new WeakMap<UIElement, SVGRenderer>();
@@ -199,7 +197,7 @@ export class D3Renderer implements UIRenderer {
 
             let Renderer: any = UIRendererMap[element.type];
             if (Renderer) {
-                let r = new Renderer(element, this, this._parent);
+                let r = new Renderer(element, this, this._parent, this._documentRoot);
                 r.setColorManager(this._colorMgr);
                 this._rendererMap.set(element, r);
             }

--- a/src/core/tooltip.ts
+++ b/src/core/tooltip.ts
@@ -147,14 +147,14 @@ export class BaseTooltip {
      * @param tooltipStyle -  css class that describes tooltip format.  Defaults
      *   to tooltip-t.
      */
-    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t') {
+    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t', documentRoot: DocumentFragment = document) {
 
-        if (!document.getElementById(tooltipDivId)) {
+        if (!documentRoot.getElementById(tooltipDivId)) {
             this._tooltipDiv = document.createElement('div');
             this._tooltipDiv.style.overflow = 'auto';
             this._tooltipDiv.id = tooltipDivId;
-            document.querySelector('body')
-                .appendChild(this._tooltipDiv);
+            let parent = documentRoot.querySelector('body') ? documentRoot.querySelector("body") : documentRoot;
+            parent.appendChild(this._tooltipDiv);
         } else {
             // Make sure the div ID has the leading '#' we need for selecting
             // a DOM object by id.
@@ -163,7 +163,7 @@ export class BaseTooltip {
                 id = '#' + tooltipDivId;
             }
 
-            this._tooltipDiv = document.querySelector(id) as HTMLDivElement;
+            this._tooltipDiv = documentRoot.querySelector(id) as HTMLDivElement;
         }
 
         this._targets = [];
@@ -845,8 +845,8 @@ export class BaseTooltip {
 export class OneLineTooltip extends BaseTooltip {
     protected _title: string;
 
-    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t') {
-        super(tooltipDivId, tooltipStyle);
+    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t', documentRoot: DocumentFragment = document) {
+        super(tooltipDivId, tooltipStyle, documentRoot);
     }
 
     public getTitle() {
@@ -889,8 +889,8 @@ export class OneLineTooltip extends BaseTooltip {
 export class MetricListTooltip extends BaseTooltip {
     protected _title: string;
 
-    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t') {
-        super(tooltipDivId, tooltipStyle);
+    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t', documentRoot: DocumentFragment = document) {
+        super(tooltipDivId, tooltipStyle, documentRoot);
     }
 
     public getTitle() {
@@ -979,8 +979,8 @@ export class MetricListTooltip extends BaseTooltip {
 }
 
 export class CustomDivTooltip extends MetricListTooltip {
-    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t') {
-        super(tooltipDivId, tooltipStyle);
+    constructor(tooltipDivId: string, tooltipStyle: string = 'tooltip-t', documentRoot: DocumentFragment = document) {
+        super(tooltipDivId, tooltipStyle, documentRoot);
     }
 
     public clearTooltip() {


### PR DESCRIPTION
This change would allow ui-widget-toolkit users to render graphs and their associated tooltips in a given Shadow DOM.  Maybe it would be useful to add similar support to the other widgets in the library, but I'm not very familiar with those.  I'd be happy to add that as well if you can give me some pointers.